### PR TITLE
Add migrate command for metadata-based file organization

### DIFF
--- a/djroid/cli/cli.py
+++ b/djroid/cli/cli.py
@@ -10,6 +10,7 @@ from djroid.services.scan import Scan
 from djroid.services.tag_interactive import TagInteractive
 from djroid.services.drop import Drop
 from djroid.services.mutate import Mutate
+from djroid.services.migrate import Migrate
 from djroid.textual.app import run_gui
 
 # Initialize logger for this module
@@ -183,6 +184,54 @@ def mutate(input_files: tuple, target_format: str):
     except Exception as e:
         logger.error(f"Failed to convert files: {str(e)}", exc_info=True)
         click.echo(f"Error converting files: {str(e)}", err=True)
+
+
+@cli.command()
+@click.argument('directory', type=click.Path(exists=True), required=False)
+@click.option('--file', type=click.Path(exists=True), help='Migrate a single file instead of a directory')
+@click.option('--dry-run', is_flag=True, help='Show what would be done without moving files')
+@click.option('--no-progress', is_flag=True, help='Disable progress bar')
+def migrate(directory: str, file: str, dry_run: bool, no_progress: bool):
+    """Migrate music files to directories based on metadata rules.
+
+    Reads file metadata (genre, artist, etc.) and moves files to destination
+    directories based on rules configured in the TUI settings.
+
+    If no directory is specified, uses the current working directory.
+    """
+    logger.info("Starting migrate operation")
+    try:
+        migrate_service = Migrate()
+
+        if file:
+            # Migrate single file
+            file_path = Path(file)
+            success = migrate_service.migrate_single_file(file_path, dry_run=dry_run)
+            if success:
+                logger.info("Single file migration completed successfully")
+            else:
+                logger.error("Single file migration failed")
+        else:
+            # Migrate directory
+            dir_path = Path(directory) if directory else Path.cwd()
+
+            result = migrate_service.migrate_directory(
+                dir_path,
+                dry_run=dry_run,
+                show_progress=not no_progress
+            )
+
+            if result['success'] > 0 or result['no_match'] > 0:
+                logger.info(
+                    f"Migration completed: {result['success']} moved, "
+                    f"{result['failed']} failed, {result['skipped']} skipped"
+                )
+            else:
+                logger.warning("No files were migrated")
+
+    except Exception as e:
+        logger.error(f"Failed to migrate files: {str(e)}", exc_info=True)
+        click.echo(f"Error migrating files: {str(e)}", err=True)
 
 
 if __name__ == '__main__':

--- a/djroid/db/__init__.py
+++ b/djroid/db/__init__.py
@@ -1,5 +1,6 @@
 from .session import Base, engine, get_db, init_database, check_database_connection
 from .models.song import Song
+from .models.migration_rule import MigrationRule
 from ..logging import get_logger
 
 logger = get_logger(__name__)

--- a/djroid/db/dao/__init__.py
+++ b/djroid/db/dao/__init__.py
@@ -1,3 +1,4 @@
 from .song_dao import SongDAO
+from .migration_rule_dao import MigrationRuleDAO
 
-__all__ = ['SongDAO']
+__all__ = ['SongDAO', 'MigrationRuleDAO']

--- a/djroid/db/dao/migration_rule_dao.py
+++ b/djroid/db/dao/migration_rule_dao.py
@@ -1,0 +1,208 @@
+"""DAO for migration rules with CRUD operations and metadata helpers."""
+
+from djroid.db.dao.base_dao import BaseDAO
+from djroid.db.models.migration_rule import MigrationRule
+from djroid.db.models.song import Song
+from sqlalchemy.orm import Session
+from sqlalchemy import func, distinct
+from typing import Optional, List
+import uuid
+
+
+class MigrationRuleDAO(BaseDAO[MigrationRule]):
+    """Data access object for migration rules."""
+
+    def __init__(self, db: Session):
+        super().__init__(MigrationRule, db)
+
+    def create(self) -> MigrationRule:
+        """Create a new empty migration rule (required by BaseDAO)."""
+        rule = MigrationRule(
+            metadata_tag="",
+            metadata_value="",
+            destination_directory=""
+        )
+        self.db.add(rule)
+        self.db.commit()
+        self.db.refresh(rule)
+        return rule
+
+    def create_rule(
+        self,
+        metadata_tag: str,
+        metadata_value: str,
+        destination_directory: str,
+        name: Optional[str] = None,
+        priority: int = 0,
+        enabled: bool = True
+    ) -> MigrationRule:
+        """Create a new migration rule with all parameters."""
+        rule = MigrationRule(
+            metadata_tag=metadata_tag,
+            metadata_value=metadata_value,
+            destination_directory=destination_directory,
+            name=name,
+            priority=priority,
+            enabled=enabled
+        )
+        self.db.add(rule)
+        self.db.commit()
+        self.db.refresh(rule)
+        return rule
+
+    def get_all_rules(self, enabled_only: bool = False) -> List[MigrationRule]:
+        """Get all migration rules, optionally filtered by enabled status."""
+        query = self.db.query(MigrationRule)
+        if enabled_only:
+            query = query.filter(MigrationRule.enabled == True)
+        return query.order_by(MigrationRule.priority.asc()).all()
+
+    def get_rules_by_tag(self, metadata_tag: str) -> List[MigrationRule]:
+        """Get all rules for a specific metadata tag."""
+        return self.db.query(MigrationRule).filter(
+            MigrationRule.metadata_tag == metadata_tag
+        ).order_by(MigrationRule.priority.asc()).all()
+
+    def get_matching_rule(
+        self,
+        metadata_tag: str,
+        metadata_value: str
+    ) -> Optional[MigrationRule]:
+        """Get the first enabled rule matching tag and value."""
+        return self.db.query(MigrationRule).filter(
+            MigrationRule.metadata_tag == metadata_tag,
+            MigrationRule.metadata_value == metadata_value,
+            MigrationRule.enabled == True
+        ).order_by(MigrationRule.priority.asc()).first()
+
+    def update_rule(
+        self,
+        rule_id: uuid.UUID,
+        metadata_tag: Optional[str] = None,
+        metadata_value: Optional[str] = None,
+        destination_directory: Optional[str] = None,
+        name: Optional[str] = None,
+        priority: Optional[int] = None,
+        enabled: Optional[bool] = None
+    ) -> Optional[MigrationRule]:
+        """Update an existing migration rule."""
+        rule = self.get(rule_id)
+        if not rule:
+            return None
+
+        if metadata_tag is not None:
+            rule.metadata_tag = metadata_tag
+        if metadata_value is not None:
+            rule.metadata_value = metadata_value
+        if destination_directory is not None:
+            rule.destination_directory = destination_directory
+        if name is not None:
+            rule.name = name
+        if priority is not None:
+            rule.priority = priority
+        if enabled is not None:
+            rule.enabled = enabled
+
+        self.db.add(rule)
+        self.db.commit()
+        self.db.refresh(rule)
+        return rule
+
+    def delete_rule(self, rule_id: uuid.UUID) -> bool:
+        """Delete a migration rule by ID."""
+        return self.delete(rule_id)
+
+    def rule_exists(self, metadata_tag: str, metadata_value: str) -> bool:
+        """Check if a rule already exists for this tag/value combination."""
+        return self.db.query(MigrationRule).filter(
+            MigrationRule.metadata_tag == metadata_tag,
+            MigrationRule.metadata_value == metadata_value
+        ).first() is not None
+
+    # Methods to get distinct values from songs table for dropdown population
+
+    def get_available_metadata_tags(self) -> List[str]:
+        """Get list of metadata tags that can be used for rules.
+
+        Returns the common metadata fields from the songs table that make
+        sense for organizing files (genre, artist, key, etc).
+        """
+        return [
+            "genre",
+            "artist",
+            "album",
+            "key",
+            "year",
+            "publisher",
+            "bpm",  # Will need special handling for ranges
+        ]
+
+    def get_distinct_genres(self) -> List[str]:
+        """Get all distinct genre values from songs table."""
+        result = self.db.query(distinct(Song.genre)).filter(
+            Song.genre.isnot(None),
+            Song.genre != ""
+        ).order_by(Song.genre).all()
+        return [r[0] for r in result]
+
+    def get_distinct_artists(self) -> List[str]:
+        """Get all distinct artist values from songs table."""
+        result = self.db.query(distinct(Song.artist)).filter(
+            Song.artist.isnot(None),
+            Song.artist != ""
+        ).order_by(Song.artist).all()
+        return [r[0] for r in result]
+
+    def get_distinct_albums(self) -> List[str]:
+        """Get all distinct album values from songs table."""
+        result = self.db.query(distinct(Song.album)).filter(
+            Song.album.isnot(None),
+            Song.album != ""
+        ).order_by(Song.album).all()
+        return [r[0] for r in result]
+
+    def get_distinct_keys(self) -> List[str]:
+        """Get all distinct key values from songs table."""
+        result = self.db.query(distinct(Song.key)).filter(
+            Song.key.isnot(None),
+            Song.key != ""
+        ).order_by(Song.key).all()
+        return [r[0] for r in result]
+
+    def get_distinct_years(self) -> List[int]:
+        """Get all distinct year values from songs table."""
+        result = self.db.query(distinct(Song.year)).filter(
+            Song.year.isnot(None)
+        ).order_by(Song.year).all()
+        return [r[0] for r in result]
+
+    def get_distinct_publishers(self) -> List[str]:
+        """Get all distinct publisher values from songs table."""
+        result = self.db.query(distinct(Song.publisher)).filter(
+            Song.publisher.isnot(None),
+            Song.publisher != ""
+        ).order_by(Song.publisher).all()
+        return [r[0] for r in result]
+
+    def get_distinct_values_for_tag(self, tag: str) -> List[str]:
+        """Get distinct values for a given metadata tag.
+
+        Args:
+            tag: The metadata tag name (genre, artist, album, key, year, publisher)
+
+        Returns:
+            List of distinct values as strings
+        """
+        tag_methods = {
+            "genre": self.get_distinct_genres,
+            "artist": self.get_distinct_artists,
+            "album": self.get_distinct_albums,
+            "key": self.get_distinct_keys,
+            "year": lambda: [str(y) for y in self.get_distinct_years()],
+            "publisher": self.get_distinct_publishers,
+        }
+
+        method = tag_methods.get(tag.lower())
+        if method:
+            return method()
+        return []

--- a/djroid/db/models/__init__.py
+++ b/djroid/db/models/__init__.py
@@ -1,3 +1,4 @@
 from .song import Song
+from .migration_rule import MigrationRule
 
-__all__ = ['Song'] 
+__all__ = ['Song', 'MigrationRule'] 

--- a/djroid/db/models/migration_rule.py
+++ b/djroid/db/models/migration_rule.py
@@ -1,0 +1,48 @@
+"""Migration rule model for storing file migration rules."""
+
+from typing import Optional
+from sqlalchemy import Integer, String, DateTime, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import mapped_column, Mapped
+from datetime import datetime, UTC
+import uuid
+from ..session import Base
+
+
+class MigrationRule(Base):
+    """Model for storing migration rules that map metadata to destination directories."""
+
+    __tablename__ = "migration_rules"
+
+    # Primary key
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True
+    )
+
+    # Rule definition
+    metadata_tag: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    metadata_value: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    destination_directory: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Optional rule name/description
+    name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
+    # Rule priority (lower = higher priority)
+    priority: Mapped[int] = mapped_column(Integer, default=0, index=True)
+
+    # Whether this rule is enabled
+    enabled: Mapped[bool] = mapped_column(default=True, index=True)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        default=datetime.now(UTC),
+        onupdate=datetime.now(UTC)
+    )
+
+    def __repr__(self) -> str:
+        return f"<MigrationRule {self.metadata_tag}:{self.metadata_value} -> {self.destination_directory}>"

--- a/djroid/services/migrate.py
+++ b/djroid/services/migrate.py
@@ -1,0 +1,430 @@
+"""Service for migrating music files to directories based on metadata rules."""
+
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional, Any, Tuple
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
+from rich.table import Table
+from rich import box
+from mutagen import File
+from djroid.logging import get_logger
+from djroid.db.session import SessionLocal
+from djroid.db.dao.migration_rule_dao import MigrationRuleDAO
+from djroid.db.dao.song_dao import SongDAO
+from djroid.db.models.migration_rule import MigrationRule
+
+logger = get_logger(__name__)
+
+
+class Migrate:
+    """
+    Service for migrating music files based on metadata-based rules.
+
+    Reads file metadata, matches against configured rules, and moves
+    files to their designated destination directories.
+    """
+
+    SUPPORTED_EXTENSIONS = {'.mp3', '.aiff', '.wav', '.flac', '.m4a', '.ogg', '.aac'}
+
+    def __init__(self):
+        """Initialize Migrate service with console output."""
+        self.console = Console()
+
+    def find_music_files(self, directory: Path) -> List[Path]:
+        """Find all music files in the given directory recursively."""
+        music_files = []
+
+        logger.info(f"Scanning directory for music files: {directory}")
+
+        for ext in self.SUPPORTED_EXTENSIONS:
+            music_files.extend(directory.rglob(f'*{ext}'))
+
+        return sorted(music_files)
+
+    def get_file_metadata(self, file_path: Path) -> Dict[str, Any]:
+        """Extract metadata from a music file using mutagen.
+
+        Args:
+            file_path: Path to the music file
+
+        Returns:
+            Dictionary of metadata fields
+        """
+        metadata = {}
+
+        try:
+            audio = File(str(file_path))
+
+            if audio is None:
+                return metadata
+
+            if not hasattr(audio, 'tags') or audio.tags is None:
+                return metadata
+
+            # Metadata fields with their tag keys
+            tag_mappings = {
+                'title': ['TIT2', 'TITLE', 'title'],
+                'artist': ['TPE1', 'ARTIST', 'artist'],
+                'album': ['TALB', 'ALBUM', 'album'],
+                'genre': ['TCON', 'GENRE', 'genre'],
+                'bpm': ['TBPM', 'BPM', 'bpm'],
+                'key': ['TKEY', 'KEY', 'key'],
+                'year': ['TDRC', 'DATE', 'date', 'year'],
+                'publisher': ['TPUB', 'PUBLISHER', 'publisher'],
+            }
+
+            for field, possible_keys in tag_mappings.items():
+                for key in possible_keys:
+                    try:
+                        if hasattr(audio.tags, 'get'):
+                            value = audio.tags.get(key)
+                            if value:
+                                if hasattr(value, 'text'):
+                                    metadata[field] = str(value.text[0])
+                                else:
+                                    metadata[field] = str(value)
+                                break
+                        elif hasattr(audio.tags, '__getitem__'):
+                            value = audio.tags[key]
+                            if value:
+                                if hasattr(value, 'text'):
+                                    metadata[field] = str(value.text[0])
+                                else:
+                                    metadata[field] = str(value)
+                                break
+                    except (KeyError, AttributeError, IndexError):
+                        continue
+
+            # Convert BPM to string for matching
+            if 'bpm' in metadata:
+                try:
+                    bpm_float = float(metadata['bpm'])
+                    metadata['bpm'] = str(int(bpm_float))
+                except (ValueError, TypeError):
+                    pass
+
+            # Extract year from date fields
+            if 'year' in metadata:
+                try:
+                    year_str = metadata['year']
+                    if year_str and len(year_str) >= 4:
+                        metadata['year'] = year_str[:4]
+                except (ValueError, TypeError):
+                    pass
+
+        except Exception as e:
+            logger.warning(f"Could not read metadata from {file_path}: {e}")
+
+        return metadata
+
+    def find_matching_rule(
+        self,
+        metadata: Dict[str, Any],
+        rules: List[MigrationRule]
+    ) -> Optional[MigrationRule]:
+        """Find the first matching migration rule for a file's metadata.
+
+        Args:
+            metadata: Dictionary of file metadata
+            rules: List of migration rules to check
+
+        Returns:
+            The first matching rule, or None if no match
+        """
+        for rule in rules:
+            tag_name = rule.metadata_tag.lower()
+            tag_value = metadata.get(tag_name, "")
+
+            if tag_value and tag_value.lower() == rule.metadata_value.lower():
+                return rule
+
+        return None
+
+    def move_file(
+        self,
+        source: Path,
+        destination_dir: Path,
+        dry_run: bool = False
+    ) -> Tuple[bool, Optional[Path]]:
+        """Move a file to the destination directory.
+
+        Args:
+            source: Source file path
+            destination_dir: Target directory
+            dry_run: If True, don't actually move the file
+
+        Returns:
+            Tuple of (success, new_path or None)
+        """
+        try:
+            # Ensure destination directory exists
+            if not dry_run:
+                destination_dir.mkdir(parents=True, exist_ok=True)
+
+            # Build destination path
+            destination = destination_dir / source.name
+
+            # Handle name collision
+            if destination.exists():
+                counter = 1
+                stem = source.stem
+                suffix = source.suffix
+                while destination.exists():
+                    destination = destination_dir / f"{stem}_{counter}{suffix}"
+                    counter += 1
+
+            if not dry_run:
+                shutil.move(str(source), str(destination))
+                logger.info(f"Moved {source} -> {destination}")
+
+            return True, destination
+
+        except Exception as e:
+            logger.error(f"Failed to move {source}: {e}")
+            return False, None
+
+    def update_database_filepath(
+        self,
+        old_path: str,
+        new_path: str
+    ) -> bool:
+        """Update the filepath in the database after moving a file.
+
+        Args:
+            old_path: Original file path
+            new_path: New file path
+
+        Returns:
+            True if database was updated, False otherwise
+        """
+        try:
+            db = SessionLocal()
+            try:
+                song_dao = SongDAO(db)
+                song = song_dao.get_by_filepath(old_path)
+                if song:
+                    song.filepath = new_path
+                    db.commit()
+                    logger.info(f"Updated database filepath: {old_path} -> {new_path}")
+                    return True
+                return False
+            finally:
+                db.close()
+        except Exception as e:
+            logger.error(f"Failed to update database filepath: {e}")
+            return False
+
+    def migrate_directory(
+        self,
+        directory: Path,
+        dry_run: bool = False,
+        show_progress: bool = True
+    ) -> Dict[str, int]:
+        """Migrate all music files in a directory based on configured rules.
+
+        Args:
+            directory: Directory to scan for music files
+            dry_run: If True, only show what would be done without moving
+            show_progress: Show progress bar
+
+        Returns:
+            Dictionary with counts: success, failed, skipped, no_match
+        """
+        results = {
+            'success': 0,
+            'failed': 0,
+            'skipped': 0,
+            'no_match': 0
+        }
+
+        # Load rules from database
+        db = SessionLocal()
+        try:
+            rule_dao = MigrationRuleDAO(db)
+            rules = rule_dao.get_all_rules(enabled_only=True)
+
+            if not rules:
+                self.console.print("[yellow]No migration rules configured.[/yellow]")
+                self.console.print("Use the TUI settings to create migration rules.")
+                return results
+
+            self.console.print(f"\n[bold]Loaded {len(rules)} migration rules[/bold]")
+
+            # Display rules summary
+            rules_table = Table(box=box.SIMPLE, show_header=True)
+            rules_table.add_column("Tag", style="cyan")
+            rules_table.add_column("Value", style="green")
+            rules_table.add_column("Destination", style="blue")
+
+            for rule in rules:
+                rules_table.add_row(
+                    rule.metadata_tag,
+                    rule.metadata_value,
+                    rule.destination_directory
+                )
+
+            self.console.print(rules_table)
+
+        finally:
+            db.close()
+
+        # Find music files
+        music_files = self.find_music_files(directory)
+
+        if not music_files:
+            self.console.print("[yellow]No music files found in directory.[/yellow]")
+            return results
+
+        self.console.print(f"\n[bold]Found {len(music_files)} music files[/bold]")
+
+        if dry_run:
+            self.console.print("[yellow][DRY RUN] No files will be moved[/yellow]\n")
+
+        # Process files
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=self.console,
+            disable=not show_progress
+        ) as progress:
+
+            task = progress.add_task("Migrating files...", total=len(music_files))
+
+            for file_path in music_files:
+                # Read metadata
+                metadata = self.get_file_metadata(file_path)
+
+                if not metadata:
+                    progress.console.print(
+                        f"[dim]Skipped (no metadata): {file_path.name}[/dim]"
+                    )
+                    results['skipped'] += 1
+                    progress.update(task, advance=1)
+                    continue
+
+                # Find matching rule
+                rule = self.find_matching_rule(metadata, rules)
+
+                if not rule:
+                    progress.console.print(
+                        f"[dim]No matching rule: {file_path.name}[/dim]"
+                    )
+                    results['no_match'] += 1
+                    progress.update(task, advance=1)
+                    continue
+
+                # Move file
+                dest_dir = Path(rule.destination_directory)
+                success, new_path = self.move_file(file_path, dest_dir, dry_run=dry_run)
+
+                if success:
+                    if dry_run:
+                        progress.console.print(
+                            f"[cyan]Would move:[/cyan] {file_path.name} -> {dest_dir}"
+                        )
+                    else:
+                        progress.console.print(
+                            f"[green]Moved:[/green] {file_path.name} -> {dest_dir}"
+                        )
+
+                        # Update database if file was tracked
+                        if new_path:
+                            self.update_database_filepath(
+                                str(file_path),
+                                str(new_path)
+                            )
+
+                    results['success'] += 1
+                else:
+                    progress.console.print(
+                        f"[red]Failed:[/red] {file_path.name}"
+                    )
+                    results['failed'] += 1
+
+                progress.update(task, advance=1)
+
+        # Summary
+        self.console.print(f"\n[bold]Migration Summary:[/bold]")
+        self.console.print(f"[green]Moved: {results['success']}[/green]")
+        self.console.print(f"[red]Failed: {results['failed']}[/red]")
+        self.console.print(f"[yellow]Skipped: {results['skipped']}[/yellow]")
+        self.console.print(f"[dim]No matching rule: {results['no_match']}[/dim]")
+
+        return results
+
+    def migrate_single_file(
+        self,
+        file_path: Path,
+        dry_run: bool = False
+    ) -> bool:
+        """Migrate a single file based on configured rules.
+
+        Args:
+            file_path: Path to the music file
+            dry_run: If True, only show what would be done
+
+        Returns:
+            True if file was migrated (or would be in dry run), False otherwise
+        """
+        if not file_path.exists():
+            self.console.print(f"[red]Error: File not found: {file_path}[/red]")
+            return False
+
+        if file_path.suffix.lower() not in self.SUPPORTED_EXTENSIONS:
+            self.console.print(f"[red]Error: Not a supported audio file: {file_path}[/red]")
+            return False
+
+        # Load rules
+        db = SessionLocal()
+        try:
+            rule_dao = MigrationRuleDAO(db)
+            rules = rule_dao.get_all_rules(enabled_only=True)
+
+            if not rules:
+                self.console.print("[yellow]No migration rules configured.[/yellow]")
+                return False
+
+        finally:
+            db.close()
+
+        # Read metadata
+        metadata = self.get_file_metadata(file_path)
+
+        if not metadata:
+            self.console.print(f"[yellow]No metadata found in file[/yellow]")
+            return False
+
+        # Display metadata
+        self.console.print(f"\n[bold]File metadata:[/bold]")
+        for key, value in metadata.items():
+            self.console.print(f"  {key}: {value}")
+
+        # Find matching rule
+        rule = self.find_matching_rule(metadata, rules)
+
+        if not rule:
+            self.console.print(f"\n[yellow]No matching migration rule found[/yellow]")
+            return False
+
+        self.console.print(f"\n[bold]Matching rule:[/bold]")
+        self.console.print(f"  {rule.metadata_tag}: {rule.metadata_value}")
+        self.console.print(f"  Destination: {rule.destination_directory}")
+
+        # Move file
+        dest_dir = Path(rule.destination_directory)
+        success, new_path = self.move_file(file_path, dest_dir, dry_run=dry_run)
+
+        if success:
+            if dry_run:
+                self.console.print(f"\n[cyan]Would move to: {dest_dir}[/cyan]")
+            else:
+                self.console.print(f"\n[green]Moved to: {new_path}[/green]")
+
+                # Update database
+                if new_path:
+                    self.update_database_filepath(str(file_path), str(new_path))
+
+        return success

--- a/djroid/textual/app.py
+++ b/djroid/textual/app.py
@@ -3,14 +3,17 @@
 from pathlib import Path
 from textual.app import App, ComposeResult
 from textual.containers import Vertical, Horizontal
+from textual.widgets import Static, Button
 
-from .messages import SongSelected, SongTagsUpdated
+from .messages import SongSelected, SongTagsUpdated, SettingsCategorySelected, TabChanged
 from .components.title_bar import TitleBar
 from .panels.navigation import NavigationHeader
 from .panels.command_palette import CommandPalette
 from .panels.playlists import PlaylistPanel
 from .panels.collection_panel import CollectionPanel
 from .panels.tag_schema_panel import TagSchemaPanel
+from .panels.settings_category_panel import SettingsCategoryPanel
+from .panels.migrate_settings_panel import MigrateSettingsPanel
 
 
 class DjroidGUI(App):
@@ -18,20 +21,136 @@ class DjroidGUI(App):
 
     CSS_PATH = Path(__file__).parent / "styles" / "styles.tcss"
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.current_tab = "library"
+        self.current_settings_category = None
+
     def compose(self) -> ComposeResult:
         with Vertical():
             yield TitleBar(id="title-bar")
             yield NavigationHeader(id="nav-header")
             with Horizontal(id="main-container"):
+                # Library view panels (shown by default)
                 yield PlaylistPanel(classes="panel", id="playlists-panel")
                 yield CollectionPanel(classes="panel", id="collection-panel")
                 yield TagSchemaPanel(classes="panel", id="tags-panel")
+
+                # Settings view panels (hidden by default)
+                settings_cat = SettingsCategoryPanel(classes="panel", id="settings-category-panel")
+                settings_cat.display = False
+                yield settings_cat
+
+                migrate_panel = MigrateSettingsPanel(classes="panel", id="migrate-settings-panel")
+                migrate_panel.display = False
+                yield migrate_panel
+
+                # Placeholder panel for other settings
+                placeholder = Static(
+                    "Select a category from the left panel.",
+                    classes="panel placeholder-panel",
+                    id="settings-placeholder-panel"
+                )
+                placeholder.display = False
+                yield placeholder
+
             yield CommandPalette(id="command-palette")
 
     def on_mount(self) -> None:
         """Called when the app starts."""
         self.title = "Djroid - AI DJ Assistant"
         self.sub_title = "Rekordbox-inspired music management"
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle navigation button presses."""
+        button_id = event.button.id
+
+        if button_id == "btn-library":
+            self.switch_to_library()
+        elif button_id == "btn-settings":
+            self.switch_to_settings()
+        elif button_id == "btn-chat":
+            # Chat not implemented yet
+            pass
+
+    def switch_to_library(self) -> None:
+        """Switch to library view."""
+        if self.current_tab == "library":
+            return
+
+        self.current_tab = "library"
+
+        # Hide settings panels
+        self.query_one("#settings-category-panel").display = False
+        self.query_one("#migrate-settings-panel").display = False
+        self.query_one("#settings-placeholder-panel").display = False
+
+        # Show library panels
+        self.query_one("#playlists-panel").display = True
+        self.query_one("#collection-panel").display = True
+        self.query_one("#tags-panel").display = True
+
+        # Update button styles
+        self._update_nav_buttons("library")
+
+    def switch_to_settings(self) -> None:
+        """Switch to settings view."""
+        if self.current_tab == "settings":
+            return
+
+        self.current_tab = "settings"
+
+        # Hide library panels
+        self.query_one("#playlists-panel").display = False
+        self.query_one("#collection-panel").display = False
+        self.query_one("#tags-panel").display = False
+
+        # Show settings category panel
+        self.query_one("#settings-category-panel").display = True
+
+        # Show the appropriate settings panel based on current category
+        if self.current_settings_category == "migrate":
+            self.query_one("#migrate-settings-panel").display = True
+            self.query_one("#settings-placeholder-panel").display = False
+        else:
+            self.query_one("#migrate-settings-panel").display = False
+            self.query_one("#settings-placeholder-panel").display = True
+
+        # Update button styles
+        self._update_nav_buttons("settings")
+
+    def _update_nav_buttons(self, active_tab: str) -> None:
+        """Update navigation button styles based on active tab."""
+        try:
+            library_btn = self.query_one("#btn-library", Button)
+            settings_btn = self.query_one("#btn-settings", Button)
+            chat_btn = self.query_one("#btn-chat", Button)
+
+            library_btn.variant = "primary" if active_tab == "library" else "default"
+            settings_btn.variant = "primary" if active_tab == "settings" else "default"
+            chat_btn.variant = "primary" if active_tab == "chat" else "default"
+        except Exception:
+            pass
+
+    def on_settings_category_selected(self, event: SettingsCategorySelected) -> None:
+        """Handle settings category selection."""
+        self.current_settings_category = event.category
+
+        # Hide all settings content panels
+        self.query_one("#migrate-settings-panel").display = False
+        self.query_one("#settings-placeholder-panel").display = False
+
+        # Show the appropriate panel
+        if event.category == "migrate":
+            migrate_panel = self.query_one("#migrate-settings-panel", MigrateSettingsPanel)
+            migrate_panel.display = True
+            migrate_panel.load_available_options()
+            migrate_panel.load_rules()
+        else:
+            # Show placeholder for unimplemented settings
+            placeholder = self.query_one("#settings-placeholder-panel")
+            placeholder.display = True
+            placeholder.update(f"{event.category.title()} settings - Coming soon")
 
     def on_song_selected(self, event: SongSelected) -> None:
         """Handle song selection - highlight tags in schema panel."""

--- a/djroid/textual/messages.py
+++ b/djroid/textual/messages.py
@@ -19,3 +19,19 @@ class SongTagsUpdated(Message):
         self.song_id = song_id
         self.has_tags = has_tags
         self.new_tags = new_tags
+
+
+class SettingsCategorySelected(Message):
+    """Message sent when a settings category is selected."""
+
+    def __init__(self, category: str) -> None:
+        super().__init__()
+        self.category = category
+
+
+class TabChanged(Message):
+    """Message sent when navigation tab changes."""
+
+    def __init__(self, tab: str) -> None:
+        super().__init__()
+        self.tab = tab  # "library", "chat", or "settings"

--- a/djroid/textual/panels/migrate_settings_panel.py
+++ b/djroid/textual/panels/migrate_settings_panel.py
@@ -1,0 +1,397 @@
+"""Migrate settings panel widget for the djroid GUI."""
+
+from pathlib import Path
+from typing import List, Optional
+import uuid
+
+from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal, ScrollableContainer
+from textual.widgets import Static, Button, Select, Input, Label
+from textual.reactive import reactive
+from rich.text import Text
+
+from ..styles.colors import HighlightColors
+from ...db.session import SessionLocal
+from ...db.dao.migration_rule_dao import MigrationRuleDAO
+from ...db.models.migration_rule import MigrationRule
+
+
+CUSTOM_OPTION = "__custom__"
+
+
+class RuleWidget(Static):
+    """Widget representing a single migration rule with dropdowns."""
+
+    def __init__(
+        self,
+        rule_id: Optional[uuid.UUID] = None,
+        metadata_tag: str = "",
+        metadata_value: str = "",
+        destination_directory: str = "",
+        available_tags: List[str] = None,
+        available_values: List[str] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.rule_id = rule_id
+        self.metadata_tag = metadata_tag
+        self.metadata_value = metadata_value
+        self.destination_directory = destination_directory
+        self.available_tags = available_tags or []
+        self.available_values = available_values or []
+
+        # Check if current value is custom (not in available values)
+        self.is_custom_value = (
+            metadata_value and
+            metadata_value not in self.available_values
+        )
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="rule-container"):
+            with Horizontal(classes="rule-row"):
+                # Metadata tag dropdown
+                tag_options = [(tag, tag) for tag in self.available_tags]
+                if self.metadata_tag and self.metadata_tag not in self.available_tags:
+                    tag_options.insert(0, (self.metadata_tag, self.metadata_tag))
+
+                yield Select(
+                    tag_options,
+                    value=self.metadata_tag if self.metadata_tag else Select.BLANK,
+                    prompt="Tag",
+                    id=f"tag-select-{self.rule_id or 'new'}",
+                    classes="rule-select tag-select"
+                )
+
+                yield Static(":", classes="rule-separator")
+
+                # Metadata value dropdown with Custom option at bottom
+                value_options = [(val, val) for val in self.available_values]
+                value_options.append(("+ Custom...", CUSTOM_OPTION))
+
+                # Determine dropdown value
+                if self.is_custom_value:
+                    dropdown_value = CUSTOM_OPTION
+                elif self.metadata_value and self.metadata_value in self.available_values:
+                    dropdown_value = self.metadata_value
+                else:
+                    dropdown_value = Select.BLANK
+
+                yield Select(
+                    value_options,
+                    value=dropdown_value,
+                    prompt="Value",
+                    id=f"value-select-{self.rule_id or 'new'}",
+                    classes="rule-select value-select"
+                )
+
+                yield Static("->", classes="rule-arrow")
+
+                # Destination directory input
+                yield Input(
+                    value=self.destination_directory,
+                    placeholder="Destination directory path",
+                    id=f"dest-input-{self.rule_id or 'new'}",
+                    classes="rule-input dest-input"
+                )
+
+                # Delete button
+                yield Button(
+                    "X",
+                    id=f"delete-btn-{self.rule_id or 'new'}",
+                    classes="rule-delete-btn",
+                    variant="error"
+                )
+
+            # Custom value input row (shown when Custom is selected)
+            custom_row = Horizontal(
+                Static("", classes="custom-spacer"),
+                Static("Custom value:", classes="custom-label"),
+                Input(
+                    value=self.metadata_value if self.is_custom_value else "",
+                    placeholder="Enter custom value",
+                    id=f"custom-value-{self.rule_id or 'new'}",
+                    classes="custom-value-input"
+                ),
+                classes="custom-row",
+                id=f"custom-row-{self.rule_id or 'new'}"
+            )
+            custom_row.display = "block" if self.is_custom_value else "none"
+            yield custom_row
+
+    def get_metadata_value(self) -> str:
+        """Get the metadata value, using custom input if Custom is selected."""
+        try:
+            value_select = self.query_one(".value-select", Select)
+
+            if value_select.value == CUSTOM_OPTION:
+                custom_input = self.query_one(".custom-value-input", Input)
+                return custom_input.value.strip()
+            elif value_select.value != Select.BLANK:
+                return value_select.value
+
+            return ""
+        except Exception:
+            return ""
+
+
+class MigrateSettingsPanel(Static):
+    """Panel for managing migration rules."""
+
+    rules: reactive[List[dict]] = reactive([])
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.available_tags = []
+        self.available_values_cache = {}
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static("MIGRATION RULES", classes="panel-header settings-header")
+            yield Static(
+                "Define rules to move files based on metadata. Select '+ Custom...' for values not in list.",
+                classes="settings-description"
+            )
+
+            with ScrollableContainer(id="rules-container"):
+                yield Static("Loading rules...", id="rules-placeholder")
+
+            with Horizontal(id="rules-actions"):
+                yield Button("+ Add Rule", id="add-rule-btn", variant="primary")
+                yield Button("Save All", id="save-rules-btn", variant="success")
+                yield Button("Refresh", id="refresh-rules-btn")
+
+    def on_mount(self) -> None:
+        """Called when the widget is mounted to the DOM."""
+        self.border_title = "Migrate Settings"
+        self.load_available_options()
+        self.load_rules()
+
+    def load_available_options(self) -> None:
+        """Load available metadata tags and cache value options."""
+        db = SessionLocal()
+        try:
+            rule_dao = MigrationRuleDAO(db)
+            self.available_tags = rule_dao.get_available_metadata_tags()
+
+            # Pre-cache values for each tag
+            for tag in self.available_tags:
+                values = rule_dao.get_distinct_values_for_tag(tag)
+                self.available_values_cache[tag] = values
+
+        except Exception as e:
+            self.available_tags = ["genre", "artist", "album", "key", "year"]
+        finally:
+            db.close()
+
+    def load_rules(self) -> None:
+        """Load existing migration rules from database."""
+        db = SessionLocal()
+        try:
+            rule_dao = MigrationRuleDAO(db)
+            rules = rule_dao.get_all_rules()
+
+            container = self.query_one("#rules-container")
+            container.remove_children()
+
+            if not rules:
+                container.mount(
+                    Static("No migration rules configured. Click '+ Add Rule' to create one.",
+                           id="rules-placeholder",
+                           classes="no-rules-message")
+                )
+                return
+
+            for rule in rules:
+                # Get available values for this rule's tag
+                available_values = self.available_values_cache.get(
+                    rule.metadata_tag.lower(), []
+                )
+
+                widget = RuleWidget(
+                    rule_id=rule.id,
+                    metadata_tag=rule.metadata_tag,
+                    metadata_value=rule.metadata_value,
+                    destination_directory=rule.destination_directory,
+                    available_tags=self.available_tags,
+                    available_values=available_values,
+                    classes="rule-widget"
+                )
+                container.mount(widget)
+
+        except Exception as e:
+            container = self.query_one("#rules-container")
+            container.remove_children()
+            container.mount(
+                Static(f"Error loading rules: {str(e)}",
+                       classes="error-message")
+            )
+        finally:
+            db.close()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button presses."""
+        button_id = event.button.id
+
+        if button_id == "add-rule-btn":
+            self.add_new_rule()
+        elif button_id == "save-rules-btn":
+            self.save_all_rules()
+        elif button_id == "refresh-rules-btn":
+            self.load_available_options()
+            self.load_rules()
+        elif button_id and button_id.startswith("delete-btn-"):
+            rule_id_str = button_id.replace("delete-btn-", "")
+            self.delete_rule(rule_id_str)
+
+    def add_new_rule(self) -> None:
+        """Add a new empty rule widget."""
+        container = self.query_one("#rules-container")
+
+        # Remove placeholder if present
+        try:
+            placeholder = container.query_one("#rules-placeholder")
+            placeholder.remove()
+        except Exception:
+            pass
+
+        # Generate a temporary ID for the new rule
+        temp_id = f"new-{uuid.uuid4().hex[:8]}"
+
+        widget = RuleWidget(
+            rule_id=None,
+            metadata_tag="",
+            metadata_value="",
+            destination_directory="",
+            available_tags=self.available_tags,
+            available_values=[],
+            id=f"rule-{temp_id}",
+            classes="rule-widget new-rule"
+        )
+        container.mount(widget)
+
+    def delete_rule(self, rule_id_str: str) -> None:
+        """Delete a rule."""
+        if rule_id_str == "new" or rule_id_str.startswith("new-"):
+            # Just remove the widget for unsaved rules
+            try:
+                container = self.query_one("#rules-container")
+                for child in container.children:
+                    if isinstance(child, RuleWidget) and (
+                        child.rule_id is None or
+                        f"rule-{rule_id_str}" == child.id
+                    ):
+                        child.remove()
+                        break
+            except Exception:
+                pass
+        else:
+            # Delete from database
+            try:
+                rule_uuid = uuid.UUID(rule_id_str)
+                db = SessionLocal()
+                try:
+                    rule_dao = MigrationRuleDAO(db)
+                    rule_dao.delete_rule(rule_uuid)
+                finally:
+                    db.close()
+
+                self.load_rules()
+
+            except Exception as e:
+                self.notify(f"Error deleting rule: {str(e)}", severity="error")
+
+    def save_all_rules(self) -> None:
+        """Save all rules to database."""
+        container = self.query_one("#rules-container")
+        saved_count = 0
+        error_count = 0
+
+        db = SessionLocal()
+        try:
+            rule_dao = MigrationRuleDAO(db)
+
+            for child in container.children:
+                if not isinstance(child, RuleWidget):
+                    continue
+
+                # Get values from the widget
+                try:
+                    tag_select = child.query_one(".tag-select", Select)
+                    dest_input = child.query_one(".dest-input", Input)
+
+                    tag = tag_select.value if tag_select.value != Select.BLANK else ""
+
+                    # Use the widget's method to get value
+                    value = child.get_metadata_value()
+
+                    dest = dest_input.value.strip()
+
+                    # Skip incomplete rules
+                    if not tag or not value or not dest:
+                        continue
+
+                    if child.rule_id:
+                        # Update existing rule
+                        rule_dao.update_rule(
+                            child.rule_id,
+                            metadata_tag=tag,
+                            metadata_value=value,
+                            destination_directory=dest
+                        )
+                    else:
+                        # Create new rule
+                        rule_dao.create_rule(
+                            metadata_tag=tag,
+                            metadata_value=value,
+                            destination_directory=dest
+                        )
+
+                    saved_count += 1
+
+                except Exception as e:
+                    error_count += 1
+
+        finally:
+            db.close()
+
+        if saved_count > 0:
+            self.notify(f"Saved {saved_count} rule(s)", severity="information")
+        if error_count > 0:
+            self.notify(f"Failed to save {error_count} rule(s)", severity="warning")
+
+        self.load_rules()
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Handle select changes."""
+        select_id = event.select.id
+
+        if select_id and "tag-select" in select_id:
+            # When tag changes, update the available values in the value select
+            new_tag = event.value
+            if new_tag and new_tag != Select.BLANK:
+                parent = event.select.parent
+                if parent:
+                    try:
+                        # Find the rule container (go up to rule-container)
+                        rule_container = parent.parent
+                        value_select = rule_container.query_one(".value-select", Select)
+                        new_values = self.available_values_cache.get(new_tag.lower(), [])
+
+                        # Build options with Custom at the end
+                        value_options = [(val, val) for val in new_values]
+                        value_options.append(("+ Custom...", CUSTOM_OPTION))
+
+                        value_select.set_options(value_options)
+                    except Exception:
+                        pass
+
+        elif select_id and "value-select" in select_id:
+            # Show/hide custom input row based on selection
+            try:
+                # Find the custom row - it's a sibling of the rule-row
+                rule_widget = event.select.parent.parent  # rule-row -> rule-container -> RuleWidget
+                if isinstance(rule_widget, RuleWidget):
+                    custom_row = rule_widget.query_one(".custom-row")
+                    custom_row.display = "block" if event.value == CUSTOM_OPTION else "none"
+            except Exception:
+                pass

--- a/djroid/textual/panels/settings_category_panel.py
+++ b/djroid/textual/panels/settings_category_panel.py
@@ -1,0 +1,31 @@
+"""Settings category panel widget for the djroid GUI."""
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static, OptionList
+from textual.widgets.option_list import Option
+
+from ..messages import SettingsCategorySelected
+
+
+class SettingsCategoryPanel(Static):
+    """Left panel showing settings categories as a clean list."""
+
+    def on_mount(self) -> None:
+        """Set the border title when mounted."""
+        self.border_title = "Settings"
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="settings-category-container"):
+            yield OptionList(
+                Option("  Migrate", id="migrate"),
+                Option("  Appearance", id="appearance"),
+                Option("  Analysis", id="analysis"),
+                Option("  Database", id="database"),
+                id="settings-option-list"
+            )
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        """Handle category selection."""
+        if event.option.id:
+            self.post_message(SettingsCategorySelected(event.option.id))

--- a/djroid/textual/styles/styles.tcss
+++ b/djroid/textual/styles/styles.tcss
@@ -415,3 +415,212 @@ Button {
     margin: 0;
     padding: 0;
 }
+
+/* ==============================================================================
+   SETTINGS PANELS
+   ============================================================================== */
+
+#settings-category-panel {
+    width: 0.8fr;
+    min-width: 24;
+    height: 1fr;
+    border-right: solid #2a2a2a;
+}
+
+#migrate-settings-panel {
+    width: 3.2fr;
+    min-width: 80;
+    height: 1fr;
+}
+
+.settings-header {
+    background: #1a1a1a;
+    color: #cccccc;
+    text-align: left;
+    height: 1;
+    padding: 0 1;
+    margin: 0;
+    text-style: bold;
+    border-bottom: solid #2a2a2a;
+}
+
+.settings-description {
+    color: #777777;
+    padding: 1;
+    height: auto;
+}
+
+#rules-container {
+    height: 1fr;
+    padding: 1;
+    background: #0a0a0a;
+}
+
+.rule-widget {
+    height: auto;
+    padding: 1;
+    margin-bottom: 1;
+    background: #1a1a1a;
+    border: solid #2a2a2a;
+}
+
+.rule-widget.new-rule {
+    border: solid #3a5a3a;
+}
+
+.rule-row {
+    height: 3;
+    align: left middle;
+    width: 100%;
+}
+
+.rule-container {
+    height: auto;
+    width: 100%;
+}
+
+.rule-select {
+    margin-right: 1;
+    height: 3;
+}
+
+.tag-select {
+    width: 16;
+}
+
+.value-select {
+    width: 28;
+}
+
+/* Custom value row - appears below main row when Custom is selected */
+.custom-row {
+    height: 3;
+    padding: 1 0 0 0;
+    align: left middle;
+}
+
+.custom-spacer {
+    width: 18;
+}
+
+.custom-label {
+    width: 14;
+    height: 3;
+    content-align: left middle;
+    color: #777777;
+}
+
+.custom-value-input {
+    width: 1fr;
+    max-width: 40;
+    height: 3;
+}
+
+.rule-separator {
+    width: 3;
+    height: 3;
+    content-align: center middle;
+    color: #777777;
+}
+
+.rule-arrow {
+    width: 4;
+    height: 3;
+    content-align: center middle;
+    color: #5ffa7f;
+    text-style: bold;
+}
+
+.rule-input {
+    width: 1fr;
+    height: 3;
+    margin: 0 1;
+}
+
+.dest-input {
+    min-width: 30;
+}
+
+.rule-delete-btn {
+    width: 5;
+    height: 3;
+    min-width: 5;
+    background: #3d1a1a;
+    color: #ff6b6b;
+    border: none;
+    content-align: center middle;
+}
+
+.rule-delete-btn:hover {
+    background: #5d2a2a;
+}
+
+#rules-actions {
+    height: 3;
+    background: #1a1a1a;
+    border-top: solid #2a2a2a;
+    padding: 0 1;
+    align: left middle;
+}
+
+#rules-actions Button {
+    margin-right: 1;
+}
+
+.no-rules-message {
+    color: #777777;
+    padding: 2;
+    text-align: center;
+}
+
+.error-message {
+    color: #ff6b6b;
+    padding: 2;
+}
+
+/* Settings Option List */
+#settings-category-container {
+    height: 1fr;
+    padding: 0;
+}
+
+#settings-option-list {
+    background: #0a0a0a;
+    color: #aaaaaa;
+    height: 1fr;
+    padding: 1 0;
+    border: none;
+}
+
+#settings-option-list:focus {
+    border: none;
+}
+
+#settings-option-list > .option-list--option {
+    padding: 0 1;
+    height: 2;
+}
+
+#settings-option-list > .option-list--option-highlighted {
+    background: #1a3d2a;
+    color: #5ffa7f;
+    text-style: bold;
+}
+
+#settings-option-list > .option-list--option-hover {
+    background: #1a1a1a;
+    color: #cccccc;
+}
+
+/* Placeholder panel for unimplemented settings */
+.placeholder-panel {
+    width: 3.2fr;
+    height: 1fr;
+    padding: 2;
+    content-align: center middle;
+}
+
+.placeholder-message {
+    color: #555555;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- Adds `dj-en migrate` CLI command that moves music files to directories based on user-defined metadata rules (genre, artist, key, etc.)
- New MigrationRule DB model/DAO with distinct value queries from the songs table
- TUI settings tab with category sidebar and rule editor panel featuring dynamic dropdowns + custom value support
- Migrate service handles metadata extraction, rule matching, file moving, and DB filepath updates

## Test plan
- [x] All imports verified
- [ ] Create rules via TUI Settings > Migrate
- [ ] Run `dj-en migrate --dry-run` to verify rule matching
- [ ] Run `dj-en migrate` to move files based on rules
- [ ] Verify DB filepath updates after migration